### PR TITLE
impl signin and auth middleware

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR "/app"
 COPY package*.json ./
 RUN npm install
 COPY . .
-CMD ["npm", "start"]
+CMD ["npm", "run", "dev"]

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,0 +1,23 @@
+const jwt = require('jsonwebtoken');
+const signingSecret = process.env.JWT_SECRET || 'supersecretstringthatwillbestoredindotenvlater'
+
+exports.jwtCheck = function (req, res, next) {
+
+    if (req.headers.authorization && req.headers.authorization.split(' ')[0] === 'Bearer') {
+
+        const token = req.headers.authorization.split(" ")[1]
+        try {
+            let decoded = jwt.verify(token, signingSecret)
+            console.log(decoded)
+            return next()
+        } catch (err) {
+            return res.status(401).json({
+                message: "Invalid credentials."
+            })
+        }
+    } else {
+        return res.status(401).json({
+            message: "Missing Authorization header."
+        })
+    }
+}


### PR DESCRIPTION
_finally_ implemented sign in and middleware to validate jwt's in a new middleware folder. i can move the jwt check into utils if you like. regardless, i wanna say auth is all done, and we can start using `jwtCheck` on all our endpoints.

also, i changed the startup command in the dockerfile to `npm run dev` for easier dev. i assumed it would be `npm run dev` on the dev branch by default, but it looks as though it's not? was that intentional, to make it easier to merge into main or something?
